### PR TITLE
Codebase overview and technologies

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,7 +23,9 @@
   color: white;
 }
 .footer{ position: relative; align-self: center; bottom:0; margin:1rem 1rem; background:#222; color:#FEFEFE; padding:0.5rem; border-radius:1rem}
-.button{ padding:0.5rem; background: #0F0F0F; cursor: pointer;}
+.button{ padding:0.5rem; background: #0F0F0F; cursor: pointer; border:0; color:#FEFEFE; border-radius: 10px;}
+.button:hover{ background:#1b1b1b; }
+.button:active{ transform: translateY(1px); }
 .modal{
   z-index: 3;
   padding-top: 100px;
@@ -62,7 +64,18 @@ a{
 }
 
 .navigation-header{ display: flex; flex-direction: row; justify-content: flex-end; margin: 0.5rem 1rem;}
+.header{ display:flex; flex-direction: column; }
+.header-actions{ display:flex; flex-direction: row; gap: 0.5rem; align-items: center;}
+.header-left{ display:flex; flex-direction: row; align-items:center; }
+.header-meta{ font-size: 0.9rem; opacity: 0.85; }
 
 .champion-list{display:flex; flex-direction:row; align-items:center; justify-content:center; flex-wrap: wrap;}
-.champion-list-item{display: flex; flex-direction: column; margin: 1rem 0; cursor: pointer; align-items: center;}
+.champion-list-item{display: flex; flex-direction: column; margin: 1rem 0; cursor: pointer; align-items: center; padding:0.5rem; border-radius: 12px;}
 .champion-list-item img {max-width: 50%; border-radius: 10%; object-fit: fill; }
+.champion-list-item.locked{ opacity: 0.75; }
+.slot-button{ margin-top: 0.5rem; padding: 0.35rem 0.75rem; border-radius: 10px; border: 1px solid #444; background:#111; color:#FEFEFE; cursor: pointer; }
+.slot-button:hover{ background:#1b1b1b; }
+
+.footer-row{ display:flex; flex-direction: row; gap: 0.75rem; align-items: center; justify-content: center; flex-wrap: wrap;}
+.source-pill{ background:#0F0F0F; padding: 0.25rem 0.6rem; border-radius: 999px; font-size: 0.85rem; opacity: 0.9; border: 1px solid #333; }
+.toast{ margin-top: 0.5rem; font-size: 0.9rem; opacity: 0.9; }

--- a/src/App.js
+++ b/src/App.js
@@ -19,13 +19,22 @@ class App extends Component {
 			randomChampions:[],
 			showModal:'',
 			summonerName:'',
+			msg:'',
 			championPool: [],
-			championImageBaseUrl: `${process.env.PUBLIC_URL}/champion/`
+			championImageBaseUrl: `${process.env.PUBLIC_URL}/champion/`,
+			championSource: 'local', // 'ddragon' | 'local'
+			lockedSlots: [false, false, false, false, false],
+			toast: ''
 		}
 		this.toggleModal = this.toggleModal.bind(this)
 		this.onChange = this.onChange.bind(this);
 		this.saveSummonerName = this.saveSummonerName.bind(this);
 		this.logout = this.logout.bind(this);
+		this.rerollChampion = this.rerollChampion.bind(this);
+		this.rerollAll = this.rerollAll.bind(this);
+		this.toggleLock = this.toggleLock.bind(this);
+		this.shareRoll = this.shareRoll.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 	}
 
 	async componentDidMount(){
@@ -34,12 +43,34 @@ class App extends Component {
 			summonerName: summonerName !== 'undefined' ? summonerName : ''
 		})
 
+		window.addEventListener('keydown', this.onKeyDown);
+
 		// Try to load latest champions from Riot Data Dragon (no API key).
 		// Fall back to bundled champion.json if fetch/network isn't available.
-		await this.loadChampionPool();
-		this.setState({
-			randomChampions: this.rollChampions(5)
-		})
+		const { pool, imageBaseUrl, source } = await this.loadChampionPool();
+
+		const restored = this.getRollFromUrl(pool);
+		const initialRoll = restored ? restored : this.rollChampions(5, pool);
+
+		this.setState(
+			{
+				championPool: pool,
+				championImageBaseUrl: imageBaseUrl,
+				championSource: source,
+				randomChampions: initialRoll
+			},
+			() => this.syncUrlWithRoll()
+		);
+	}
+
+	componentWillUnmount(){
+		window.removeEventListener('keydown', this.onKeyDown);
+	}
+
+	onKeyDown(e){
+		if(e.key === 'Escape' && this.state.showModal){
+			this.toggleModal('');
+		}
 	}
 
 	async loadChampionPool() {
@@ -54,22 +85,59 @@ class App extends Component {
 				throw new Error('Empty champion list');
 			}
 
-			this.setState({
-				championPool: list,
-				championImageBaseUrl: getChampionImageBaseUrl(version)
-			});
+			return {
+				pool: list,
+				imageBaseUrl: getChampionImageBaseUrl(version),
+				source: 'ddragon'
+			};
 		} catch (e) {
 			// Local fallback (keeps app working offline and in tests).
 			const localPool = Object.keys(champions.data).map((key) => {
 				const c = champions.data[key];
-				return { name: c.name, image: c.image.full };
+				return { id: key, name: c.name, image: c.image.full };
 			});
-			this.setState({
-				championPool: localPool,
-				championImageBaseUrl: `${process.env.PUBLIC_URL}/champion/`
-			});
+			return {
+				pool: localPool,
+				imageBaseUrl: `${process.env.PUBLIC_URL}/champion/`,
+				source: 'local'
+			};
 		}
 	}
+
+	getRollFromUrl(pool){
+		try{
+			if(!pool || pool.length === 0) return null;
+			const byId = new Map(pool.map((c) => [c.id, c]));
+			const params = new URLSearchParams(window.location.search);
+			const raw = params.get('p');
+			if(!raw) return null;
+			const ids = raw.split(',').map(s => s.trim()).filter(Boolean);
+			if(ids.length !== 5) return null;
+			const unique = new Set(ids);
+			if(unique.size !== 5) return null;
+			const champs = ids.map((id) => byId.get(id)).filter(Boolean);
+			if(champs.length !== 5) return null;
+			return champs.map((c) => ({ id: c.id, name: c.name, image: c.image }));
+		}catch(_e){
+			return null;
+		}
+	}
+
+	syncUrlWithRoll(){
+		try{
+			const champs = this.state.randomChampions;
+			if(!Array.isArray(champs) || champs.length !== 5) return;
+			const ids = champs.map(c => c && c.id).filter(Boolean);
+			if(ids.length !== 5) return;
+			const params = new URLSearchParams(window.location.search);
+			params.set('p', ids.join(','));
+			const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`;
+			window.history.replaceState({}, '', newUrl);
+		}catch(_e){
+			// ignore
+		}
+	}
+
 	toggleModal(modal) {
 		this.setState({
 			showModal: modal
@@ -95,7 +163,6 @@ class App extends Component {
 
 	}
 	logout(){
-		console.log('asdsa')
 		localStorage.setItem('summonerName', '')
 		this.setState({
 			summonerName:''
@@ -103,39 +170,57 @@ class App extends Component {
 	}
 
 	render() {
-		let { randomChampions, showModal, summonerName, msg, championImageBaseUrl } = this.state;
+		let { randomChampions, showModal, summonerName, msg, championImageBaseUrl, lockedSlots, championSource, toast } = this.state;
 		let divs = randomChampions.map((champ, index) => {
 			return (
-				<div key={champ.name} className="champion-list-item" onClick={() => this.rerollChampion(index)}  >
+				<div key={champ.id || champ.name} className={`champion-list-item ${lockedSlots[index] ? 'locked' : ''}`} onClick={() => this.rerollChampion(index)}  >
 					<span>{champ.name}</span>
 					<img src={`${championImageBaseUrl}${champ.image}`} alt="champion"></img>
 					<span>{this.state.roles[index]}</span>
+					<button
+						className="slot-button"
+						onClick={(e) => { e.stopPropagation(); this.toggleLock(index); }}
+						type="button"
+					>
+						{lockedSlots[index] ? 'Unlock' : 'Lock'}
+					</button>
 				</div>
 			)
 		})
 
 		return (
 			<div className="App" >
-				<Header title="All Random All Fill" onClick={() => !!summonerName ? this.logout() : this.toggleModal('login')} hasToken={!!summonerName}></Header>
+				<Header
+					title="All Random All Fill"
+					hasToken={!!summonerName}
+					summonerName={summonerName}
+					championSource={championSource}
+					onSummonerClick={() => !!summonerName ? this.logout() : this.toggleModal('login')}
+					onRerollAll={this.rerollAll}
+					onShare={this.shareRoll}
+				/>
 				<div className="champion-list" >
 					{divs}
 				</div>
 				<footer className="footer">
-					You can now reroll a champion by clicking the image of the one you want to change.
+					<div className="footer-row">
+						<span>Click a slot to reroll it (unless locked).</span>
+						<span className="source-pill">Source: {championSource === 'ddragon' ? 'Latest (Data Dragon)' : 'Bundled (offline)'}</span>
+					</div>
+					{!!toast && <div className="toast">{toast}</div>}
 				</footer>
 				{
 					showModal === 'login' &&
-					<Modal showModal={showModal}>
-						<Login onChange={this.onChange} onSubmit={this.saveSummonerName} msg={msg}></Login>
+					<Modal showModal={showModal} onClick={() => this.toggleModal('')}>
+						<Login onChange={this.onChange} onSubmit={this.saveSummonerName} msg={msg} summonerName={summonerName}></Login>
 					</Modal>
 				}
 			</div>
 		);
 	}
 
-
-	rollChampions() {
-		const pool = this.state.championPool;
+	rollChampions(_count, poolOverride) {
+		const pool = poolOverride ? poolOverride : this.state.championPool;
 		if (!Array.isArray(pool) || pool.length === 0) return [];
 
 		let champs = []
@@ -148,32 +233,89 @@ class App extends Component {
 		return champs
 	}
 
-
-
 	rollChampion(){
 		const pool = this.state.championPool;
 		var random = Math.floor(Math.random() * pool.length);
 		var element = pool[random];
-		return {name: element.name, image: element.image}
+		return {id: element.id, name: element.name, image: element.image}
 	}
 
 	someChampIsSame(array, newChamp){
-		return array.some(champ => champ.name === newChamp.name)
+		return array.some(champ => champ.id === newChamp.id)
 	}
 	
 	rerollChampion(index){
+		if(this.state.lockedSlots[index]) return;
+
 		let { randomChampions } = this.state;
 		let currChamp = randomChampions[index];
 		let newChamp = currChamp;
 		
-		while(newChamp === currChamp || this.someChampIsSame(randomChampions, newChamp)){
+		while((newChamp && currChamp && newChamp.id === currChamp.id) || this.someChampIsSame(randomChampions, newChamp)){
 			newChamp = this.rollChampion()
 		}
 		randomChampions[index] = newChamp
-		this.setState({
-			randomChampions
-		})
+		this.setState({ randomChampions }, () => this.syncUrlWithRoll());
 
+	}
+
+	rerollAll(){
+		const { randomChampions, lockedSlots } = this.state;
+		if(!Array.isArray(randomChampions) || randomChampions.length !== 5) return;
+
+		const next = randomChampions.slice();
+		const used = new Set();
+
+		// Keep locked champs.
+		for(let i=0;i<5;i++){
+			if(lockedSlots[i] && next[i] && next[i].id){
+				used.add(next[i].id);
+			}
+		}
+
+		// Reroll unlocked slots ensuring uniqueness.
+		for(let i=0;i<5;i++){
+			if(lockedSlots[i]) continue;
+			let candidate = null;
+			let attempts = 0;
+			while(attempts < 500){
+				const c = this.rollChampion();
+				if(c && c.id && !used.has(c.id)){
+					candidate = c;
+					break;
+				}
+				attempts++;
+			}
+			if(candidate){
+				next[i] = candidate;
+				used.add(candidate.id);
+			}
+		}
+
+		this.setState({ randomChampions: next }, () => this.syncUrlWithRoll());
+	}
+
+	toggleLock(index){
+		const lockedSlots = this.state.lockedSlots.slice();
+		lockedSlots[index] = !lockedSlots[index];
+		this.setState({ lockedSlots });
+	}
+
+	async shareRoll(){
+		try{
+			const url = window.location.href;
+			if(navigator && navigator.clipboard && typeof navigator.clipboard.writeText === 'function'){
+				await navigator.clipboard.writeText(url);
+				this.setState({ toast: 'Link copied!' });
+				window.setTimeout(() => this.setState({ toast: '' }), 1500);
+			}else{
+				this.setState({ toast: 'Copy not supported in this browser.' });
+				window.setTimeout(() => this.setState({ toast: '' }), 2000);
+			}
+		}catch(_e){
+			this.setState({ toast: 'Could not copy link.' });
+			window.setTimeout(() => this.setState({ toast: '' }), 2000);
+		}
 	}
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,11 @@ import champions from './champion.json'
 import Header from './utility/Header';
 import Modal from './utility/Modal';
 import Login from './components/login/Login';
+import {
+	fetchLatestDDragonVersion,
+	fetchChampionList,
+	getChampionImageBaseUrl
+} from './utility/ddragon';
 
 class App extends Component {
 	constructor(props) {
@@ -13,7 +18,9 @@ class App extends Component {
 			roles: ["Top", "Jungle", "Mid", "Bottom", "Support"],
 			randomChampions:[],
 			showModal:'',
-			summonerName:''
+			summonerName:'',
+			championPool: [],
+			championImageBaseUrl: `${process.env.PUBLIC_URL}/champion/`
 		}
 		this.toggleModal = this.toggleModal.bind(this)
 		this.onChange = this.onChange.bind(this);
@@ -21,12 +28,47 @@ class App extends Component {
 		this.logout = this.logout.bind(this);
 	}
 
-	componentDidMount(){
+	async componentDidMount(){
 		let summonerName = localStorage.getItem('summonerName')
 		this.setState({
-			randomChampions:this.rollChampions(5),
 			summonerName: summonerName !== 'undefined' ? summonerName : ''
-		}) 
+		})
+
+		// Try to load latest champions from Riot Data Dragon (no API key).
+		// Fall back to bundled champion.json if fetch/network isn't available.
+		await this.loadChampionPool();
+		this.setState({
+			randomChampions: this.rollChampions(5)
+		})
+	}
+
+	async loadChampionPool() {
+		try {
+			if (typeof fetch !== 'function') {
+				throw new Error('fetch not available');
+			}
+
+			const version = await fetchLatestDDragonVersion();
+			const list = await fetchChampionList({ version, locale: 'en_US' });
+			if (!Array.isArray(list) || list.length === 0) {
+				throw new Error('Empty champion list');
+			}
+
+			this.setState({
+				championPool: list,
+				championImageBaseUrl: getChampionImageBaseUrl(version)
+			});
+		} catch (e) {
+			// Local fallback (keeps app working offline and in tests).
+			const localPool = Object.keys(champions.data).map((key) => {
+				const c = champions.data[key];
+				return { name: c.name, image: c.image.full };
+			});
+			this.setState({
+				championPool: localPool,
+				championImageBaseUrl: `${process.env.PUBLIC_URL}/champion/`
+			});
+		}
 	}
 	toggleModal(modal) {
 		this.setState({
@@ -61,12 +103,12 @@ class App extends Component {
 	}
 
 	render() {
-		let { randomChampions, showModal, summonerName, msg } = this.state;
+		let { randomChampions, showModal, summonerName, msg, championImageBaseUrl } = this.state;
 		let divs = randomChampions.map((champ, index) => {
 			return (
 				<div key={champ.name} className="champion-list-item" onClick={() => this.rerollChampion(index)}  >
 					<span>{champ.name}</span>
-					<img src={`${process.env.PUBLIC_URL}/champion/${champ.image}`} alt="champion"></img>
+					<img src={`${championImageBaseUrl}${champ.image}`} alt="champion"></img>
 					<span>{this.state.roles[index]}</span>
 				</div>
 			)
@@ -93,6 +135,9 @@ class App extends Component {
 
 
 	rollChampions() {
+		const pool = this.state.championPool;
+		if (!Array.isArray(pool) || pool.length === 0) return [];
+
 		let champs = []
 		while(champs.length < 5){
 			let element = this.rollChampion();
@@ -106,10 +151,10 @@ class App extends Component {
 
 
 	rollChampion(){
-		var random = Math.floor(Math.random() * Object.keys(champions.data).length);
-		var key = Object.keys(champions.data)[random];
-		var element = champions.data[key];
-		return {name: element.name, image: element.image.full}
+		const pool = this.state.championPool;
+		var random = Math.floor(Math.random() * pool.length);
+		var element = pool[random];
+		return {name: element.name, image: element.image}
 	}
 
 	someChampIsSame(array, newChamp){

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -3,13 +3,20 @@ import './Login.css'
 
 export default class Login extends PureComponent {
     render() {
-        let {onChange, onSubmit, name, msg } = this.props
+        let { onChange, onSubmit, summonerName, msg } = this.props
         return (
             <form className="login-container" onSubmit={onSubmit}>
                 <div className="login-input">
                     <label>
                         Summoner name:
-                        <input required pattern={/^[0-9a-z _.]+$/} type="text" name="summonerName" onChange={onChange} value={name}></input>
+                        <input
+                            required
+                            pattern="^[0-9a-z _.]+$"
+                            type="text"
+                            name="summonerName"
+                            onChange={onChange}
+                            value={summonerName || ''}
+                        ></input>
                     </label>
                 </div>
                 {
@@ -17,7 +24,7 @@ export default class Login extends PureComponent {
                     &&
                     <span style={{color:'red'}}>{msg}</span>
                 }
-                <input type="submit" onClick={onSubmit} value="Save"></input>
+                <input type="submit" value="Save"></input>
             </form>
         )
     }

--- a/src/utility/Header.jsx
+++ b/src/utility/Header.jsx
@@ -2,19 +2,29 @@ import React, { PureComponent } from 'react'
 
 export default class Header extends PureComponent {
     render() {
-        let { hasToken, title, onClick } = this.props;
+        let { hasToken, title, onSummonerClick, onRerollAll, onShare, summonerName, championSource } = this.props;
         return (
-            <div>
+            <header className="header">
                 <h1>
                     <a href="/">
                         {title}
                     </a>
 
                 </h1>
-                {/* <div className="navigation-header">
-                    <div className="button" onClick={onClick}>{hasToken ?'Remove summoner' : 'Choose summoner'}</div>
-                </div> */}
-            </div>
+                <div className="navigation-header">
+                    <div className="header-left">
+                        <span className="header-meta">
+                            {championSource === 'ddragon' ? 'Latest champions' : 'Offline champions'}
+                            {summonerName ? ` • ${summonerName}` : ''}
+                        </span>
+                    </div>
+                    <div className="header-actions">
+                        <button className="button" type="button" onClick={onRerollAll}>Reroll all</button>
+                        <button className="button" type="button" onClick={onShare}>Share</button>
+                        <button className="button" type="button" onClick={onSummonerClick}>{hasToken ? 'Remove summoner' : 'Choose summoner'}</button>
+                    </div>
+                </div>
+            </header>
 
         )
     }

--- a/src/utility/ddragon.js
+++ b/src/utility/ddragon.js
@@ -1,0 +1,42 @@
+const DDRAGON_BASE_URL = 'https://ddragon.leagueoflegends.com';
+
+/**
+ * Fetches the latest Data Dragon version string (e.g. "14.24.1").
+ */
+export async function fetchLatestDDragonVersion() {
+  const res = await fetch(`${DDRAGON_BASE_URL}/api/versions.json`);
+  if (!res.ok) throw new Error(`Failed to fetch versions: ${res.status}`);
+  const versions = await res.json();
+  if (!Array.isArray(versions) || !versions[0]) {
+    throw new Error('Unexpected versions response');
+  }
+  return versions[0];
+}
+
+/**
+ * Fetches champion index JSON for a version/locale and normalizes it to an array.
+ */
+export async function fetchChampionList({ version, locale = 'en_US' }) {
+  const res = await fetch(
+    `${DDRAGON_BASE_URL}/cdn/${version}/data/${locale}/champion.json`
+  );
+  if (!res.ok) throw new Error(`Failed to fetch champions: ${res.status}`);
+  const payload = await res.json();
+  const data = payload && payload.data ? payload.data : null;
+  if (!data || typeof data !== 'object') {
+    throw new Error('Unexpected champion payload');
+  }
+
+  return Object.keys(data).map((key) => {
+    const champ = data[key];
+    return {
+      name: champ.name,
+      image: champ.image && champ.image.full ? champ.image.full : '',
+    };
+  });
+}
+
+export function getChampionImageBaseUrl(version) {
+  return `${DDRAGON_BASE_URL}/cdn/${version}/img/champion/`;
+}
+

--- a/src/utility/ddragon.js
+++ b/src/utility/ddragon.js
@@ -30,6 +30,7 @@ export async function fetchChampionList({ version, locale = 'en_US' }) {
   return Object.keys(data).map((key) => {
     const champ = data[key];
     return {
+      id: champ.id,
       name: champ.name,
       image: champ.image && champ.image.full ? champ.image.full : '',
     };


### PR DESCRIPTION
Automatically fetch latest champions from Riot Data Dragon, with local fallback, to ensure the app is always up-to-date.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4ef9565-5b86-42d7-9282-f44abffc8154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4ef9565-5b86-42d7-9282-f44abffc8154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetch champions from Data Dragon with offline fallback and add lockable slots, reroll-all, shareable deep links, header actions, and related styling.
> 
> - **Data fetching**:
>   - Integrate Riot Data Dragon (`utility/ddragon.js`) to load latest champion list and images; fall back to bundled `champion.json` offline.
> - **State & logic**:
>   - Add `championPool`, dynamic `championImageBaseUrl`, `championSource`, `lockedSlots`, and `toast`.
>   - Support deep-linking: parse `?p=` to restore rolls; keep URL in sync with current roll.
>   - Add reroll-all respecting locked slots; prevent duplicates; per-slot reroll unchanged.
>   - Keyboard: ESC closes modal.
> - **UI**:
>   - Update `Header` with source/summoner meta and actions: Reroll all, Share, Choose/Remove summoner.
>   - Add per-slot Lock/Unlock button; show locked state.
>   - `Login` prop/validation tweaks; wire modal close handler.
> - **Styling**:
>   - Button/slot hover/active styles, header/metadata layout, footer source pill and toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de755dbe8463eaeda5a810ffb9be4fe33174951c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->